### PR TITLE
Actually use bash, not sh

### DIFF
--- a/godaddy-dyndns.sh
+++ b/godaddy-dyndns.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -ex
 
 set +x
 OLD_PWD=$PWD


### PR DESCRIPTION
`source` doesn't work in `sh` in most distros, I don't think.
